### PR TITLE
Modified TextFieldBoxes to accept Drawables for IconSignifier and endicon

### DIFF
--- a/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
+++ b/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
@@ -782,6 +782,14 @@ public class TextFieldBoxes extends FrameLayout {
         } else removeIconSignifier();
     }
 
+    public void setIconSignifier(Drawable drawable) {
+
+        removeIconSignifier();
+        this.iconImageButton.setImageDrawable(drawable);
+        this.iconImageButton.setVisibility(View.VISIBLE);
+
+    }
+
     /**
      * remove the icon by setting the visibility of the image view to View.GONE
      */
@@ -798,6 +806,12 @@ public class TextFieldBoxes extends FrameLayout {
             this.endIconImageButton.setImageResource(this.endIconResourceId);
             this.endIconImageButton.setVisibility(View.VISIBLE);
         } else removeEndIcon();
+    }
+
+    public void setEndIcon(Drawable drawable) {
+        removeEndIcon();
+        this.endIconImageButton.setImageDrawable(drawable);
+        this.endIconImageButton.setVisibility(View.VISIBLE);
     }
 
     /**


### PR DESCRIPTION
in my case i had to use icons from https://github.com/mikepenz/Android-Iconics
storing all icons in res/drawable may not be a good thing. hence i made changes  for IconSignifier and endicon to accept Drawables