### PR TITLE
add support for any type of class (must extend TextView)

### DIFF
--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -141,6 +141,20 @@
 
         </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 
+        <studio.carbonylgroup.textfieldboxes.TextFieldBoxes
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            app:hasFocus="false"
+            app:labelText="Read only field">
+
+            <studio.carbonylgroup.textfieldboxes.ExtendedTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Cannot change this value"/>
+
+        </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
+
         <Button
             android:id="@+id/dark_button"
             android:layout_width="match_parent"

--- a/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/EmbeddedTextField.java
+++ b/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/EmbeddedTextField.java
@@ -1,0 +1,10 @@
+package studio.carbonylgroup.textfieldboxes;
+
+import android.view.View;
+
+/**
+ * Define the interactions between a {@link TextFieldBoxes} and its child view.
+ */
+public interface EmbeddedTextField {
+    void setDefaultOnFocusChangeListener(View.OnFocusChangeListener l);
+}

--- a/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/ExtendedTextView.java
+++ b/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/ExtendedTextView.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
 
 
@@ -17,7 +18,7 @@ import android.util.AttributeSet;
  * Created by CarbonylGroup on 2017/09/01
  */
 @SuppressWarnings("unused")
-public class ExtendedEditText extends TextInputAutoCompleteTextView implements EmbeddedTextField {
+public class ExtendedTextView extends AppCompatTextView implements EmbeddedTextField {
 
     public int DEFAULT_TEXT_COLOR;
     private OnFocusChangeListener defaultFocusListener;
@@ -43,22 +44,22 @@ public class ExtendedEditText extends TextInputAutoCompleteTextView implements E
      */
     protected int suffixTextColor;
 
-    public ExtendedEditText(Context context) {
+    public ExtendedTextView(Context context) {
 
         this(context, null);
         super.setOnFocusChangeListener(focusListener);
         initDefaultColor();
     }
 
-    public ExtendedEditText(Context context, AttributeSet attrs) {
+    public ExtendedTextView(Context context, AttributeSet attrs) {
 
-        this(context, attrs, android.R.attr.editTextStyle);
+        this(context, attrs, android.R.attr.textViewStyle);
         super.setOnFocusChangeListener(focusListener);
         initDefaultColor();
         handleAttributes(context, attrs);
     }
 
-    public ExtendedEditText(Context context, AttributeSet attrs, int defStyle) {
+    public ExtendedTextView(Context context, AttributeSet attrs, int defStyle) {
 
         super(context, attrs, defStyle);
         super.setOnFocusChangeListener(focusListener);
@@ -110,19 +111,19 @@ public class ExtendedEditText extends TextInputAutoCompleteTextView implements E
     protected void handleAttributes(Context context, AttributeSet attrs) {
         try {
 
-            TypedArray styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.ExtendedEditText);
+            TypedArray styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.ExtendedTextView);
 
             /* Texts */
-            this.prefix = styledAttrs.getString(R.styleable.ExtendedEditText_prefix)
-                    == null ? "" : styledAttrs.getString(R.styleable.ExtendedEditText_prefix);
-            this.suffix = styledAttrs.getString(R.styleable.ExtendedEditText_suffix)
-                    == null ? "" : styledAttrs.getString(R.styleable.ExtendedEditText_suffix);
+            this.prefix = styledAttrs.getString(R.styleable.ExtendedTextView_prefix)
+                    == null ? "" : styledAttrs.getString(R.styleable.ExtendedTextView_prefix);
+            this.suffix = styledAttrs.getString(R.styleable.ExtendedTextView_suffix)
+                    == null ? "" : styledAttrs.getString(R.styleable.ExtendedTextView_suffix);
 
             /* Colors */
             this.prefixTextColor = styledAttrs
-                    .getInt(R.styleable.ExtendedEditText_prefixTextColor, DEFAULT_TEXT_COLOR);
+                    .getInt(R.styleable.ExtendedTextView_prefixTextColor, DEFAULT_TEXT_COLOR);
             this.suffixTextColor = styledAttrs
-                    .getInt(R.styleable.ExtendedEditText_suffixTextColor, DEFAULT_TEXT_COLOR);
+                    .getInt(R.styleable.ExtendedTextView_suffixTextColor, DEFAULT_TEXT_COLOR);
             styledAttrs.recycle();
 
         } catch (Exception e) {

--- a/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
+++ b/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
@@ -20,6 +20,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
@@ -141,7 +142,7 @@ public class TextFieldBoxes extends FrameLayout {
     protected Space labelSpace;
     protected Space labelSpaceBelow;
     protected ViewGroup editTextLayout;
-    protected ExtendedEditText editText;
+    protected TextView editText;
     protected RelativeLayout rightShell;
     protected RelativeLayout upperPanel;
     protected RelativeLayout bottomPart;
@@ -215,11 +216,12 @@ public class TextFieldBoxes extends FrameLayout {
         themeArray.recycle();
     }
 
-    protected ExtendedEditText findEditTextChild() {
+    protected TextView findEditTextChild() {
 
-        if (getChildCount() > 0 && getChildAt(0) instanceof ExtendedEditText)
-            return (ExtendedEditText) getChildAt(0);
-        return null;
+        if (getChildCount() > 0 && getChildAt(0) instanceof TextView)
+            return (TextView) getChildAt(0);
+        throw new IllegalArgumentException(getClass().getSimpleName()
+                + " must be used with one child view that extends TextView");
     }
 
     @Override
@@ -349,7 +351,9 @@ public class TextFieldBoxes extends FrameLayout {
         removeView(this.editText);
 
         this.editText.setBackgroundColor(Color.TRANSPARENT);
-        this.editText.setDropDownBackgroundDrawable(new ColorDrawable(DEFAULT_FG_COLOR));
+        if (this.editText instanceof AutoCompleteTextView) {
+            ((AutoCompleteTextView) this.editText).setDropDownBackgroundDrawable(new ColorDrawable(DEFAULT_FG_COLOR));
+        }
         this.inputLayout = this.findViewById(R.id.text_field_boxes_input_layout);
         this.inputLayout.addView(this.editText);
         this.inputLayout.setAlpha(0f);
@@ -384,7 +388,11 @@ public class TextFieldBoxes extends FrameLayout {
             public void onClick(View v) {
                 if (!isActivated()) activate(true);
                 setHasFocus(true);
-                inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                if (editText instanceof EditText) {
+                    inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                } else {
+                    inputMethodManager.hideSoftInputFromWindow(editText.getWindowToken(), 0);
+                }
                 mainBody.performClick();
             }
         });
@@ -394,18 +402,24 @@ public class TextFieldBoxes extends FrameLayout {
             public void onClick(View v) {
                 if (!isActivated()) activate(true);
                 setHasFocus(true);
-                inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                if (editText instanceof EditText) {
+                    inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                } else {
+                    inputMethodManager.hideSoftInputFromWindow(editText.getWindowToken(), 0);
+                }
                 mainBody.performClick();
             }
         });
 
-        this.editText.setDefaultOnFocusChangeListener(new OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View view, boolean b) {
-                if (b) setHasFocus(true);
-                else setHasFocus(false);
-            }
-        });
+        if (this.editText instanceof EmbeddedTextField) {
+            ((EmbeddedTextField) this.editText).setDefaultOnFocusChangeListener(new OnFocusChangeListener() {
+                @Override
+                public void onFocusChange(View view, boolean b) {
+                    if (b) setHasFocus(true);
+                    else setHasFocus(false);
+                }
+            });
+        }
 
         this.editText.addTextChangedListener(new TextWatcher() {
             @Override
@@ -562,12 +576,16 @@ public class TextFieldBoxes extends FrameLayout {
                     this.editText.setText("");
                 }
             } else {
-                this.editText.setSelection(1);
-                this.editText.setSelection(0);
+                if (this.editText instanceof EditText) {
+                    ((EditText) this.editText).setSelection(1);
+                    ((EditText) this.editText).setSelection(0);
+                }
             }
         else {
-            this.editText.setSelection(0);
-            this.editText.setSelection(cursorPos);
+            if (this.editText instanceof EditText) {
+                ((EditText) this.editText).setSelection(0);
+                ((EditText) this.editText).setSelection(cursorPos);
+            }
         }
     }
 
@@ -1101,7 +1119,7 @@ public class TextFieldBoxes extends FrameLayout {
     /**
      * set EditText cursor color
      */
-    protected static void setCursorDrawableColor(EditText _editText, int _colorRes) {
+    protected static void setCursorDrawableColor(TextView _editText, int _colorRes) {
 
         try {
             Field fCursorDrawableRes = TextView.class.getDeclaredField("mCursorDrawableRes");

--- a/textfieldboxes/src/main/res/values/attrs.xml
+++ b/textfieldboxes/src/main/res/values/attrs.xml
@@ -29,15 +29,35 @@
 
     </declare-styleable>
 
+    <!--Texts-->
+    <attr name="prefix" format="string" />
+    <attr name="suffix" format="string" />
+
+    <!--Colors-->
+    <attr name="prefixTextColor" format="color" />
+    <attr name="suffixTextColor" format="color" />
+
     <declare-styleable name="ExtendedEditText">
 
         <!--Texts-->
-        <attr name="prefix" format="string" />
-        <attr name="suffix" format="string" />
+        <attr name="prefix" />
+        <attr name="suffix" />
 
         <!--Colors-->
-        <attr name="prefixTextColor" format="color" />
-        <attr name="suffixTextColor" format="color" />
+        <attr name="prefixTextColor" />
+        <attr name="suffixTextColor" />
+
+    </declare-styleable>
+
+    <declare-styleable name="ExtendedTextView">
+
+        <!--Texts-->
+        <attr name="prefix" />
+        <attr name="suffix" />
+
+        <!--Colors-->
+        <attr name="prefixTextColor" />
+        <attr name="suffixTextColor" />
 
     </declare-styleable>
 


### PR DESCRIPTION
The link between the child of TextFieldBoxes and the TextFieldBoxes is established through an interface. This only for the focus change listener.
The class of the child is relaxed to be anything that extends TextView (simple read-only text view, auto-complete, EditText, etc.)
A sample is provided with a TextView.

This derived from my request in #43 