### PR TITLE
Calling setError method will update visibility of the bottom bar

### DIFF
--- a/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
+++ b/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
@@ -15,10 +15,12 @@ import studio.carbonylgroup.textfieldboxes.TextFieldBoxes;
 
 public class MainActivity extends AppCompatActivity {
 
+    private SharedPreferences sharedPreferences;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
-        final SharedPreferences sharedPreferences = this.getSharedPreferences("theme", Context.MODE_PRIVATE);
+        sharedPreferences = this.getSharedPreferences("theme", Context.MODE_PRIVATE);
         final boolean dark = sharedPreferences.getBoolean("dark", false);
         setTheme(dark ? R.style.AppThemeDark : R.style.AppTheme);
 
@@ -34,6 +36,12 @@ public class MainActivity extends AppCompatActivity {
         t.setThreshold(1);
         t.setAdapter(adapter);
 
+        setupDarkThemeButton(dark);
+        setupErrorButton();
+    }
+
+    private void setupDarkThemeButton(final boolean dark) {
+
         final Button darkButton = findViewById(R.id.dark_button);
 
         darkButton.setText(dark ? "LIGHT SIDE" : "DARK SIDE");
@@ -47,7 +55,9 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(i);
             }
         });
+    }
 
+    private void setupErrorButton(){
         final Button errorButton = findViewById(R.id.error_button);
         final TextFieldBoxes errorField = findViewById(R.id.text_field_boxes5);
         errorButton.setOnClickListener(new View.OnClickListener() {
@@ -57,4 +67,6 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
+
+
 }

--- a/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
+++ b/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
@@ -3,9 +3,8 @@ package studio.carbonylgroup.textfieldboxestest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-import android.util.Log;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -46,6 +45,15 @@ public class MainActivity extends AppCompatActivity {
                         .getLaunchIntentForPackage(getBaseContext().getPackageName());
                 i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(i);
+            }
+        });
+
+        final Button errorButton = findViewById(R.id.error_button);
+        final TextFieldBoxes errorField = findViewById(R.id.text_field_boxes5);
+        errorButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                errorField.setError("Invalid coupon code.", false);
             }
         });
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scrollbarStyle="outsideOverlay"
-    tools:context=".MainActivity">
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbarStyle="outsideOverlay"
+            tools:context=".MainActivity">
 
     <!--<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"-->
     <!--xmlns:app="http://schemas.android.com/apk/res-auto"-->
@@ -65,7 +65,7 @@
                 android:imeOptions="actionNext"
                 android:inputType="text"
                 android:maxLines="1"
-                android:text="@string/title" />
+                android:text="@string/title"/>
 
         </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 
@@ -93,7 +93,7 @@
                     android:inputType="text"
                     android:maxLines="1"
                     android:text="@string/price"
-                    app:prefix="$ " />
+                    app:prefix="$ "/>
 
             </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 
@@ -121,7 +121,7 @@
                     android:inputType="text"
                     android:maxLines="1"
                     android:popupElevation="5dp"
-                    android:text="" />
+                    android:text=""/>
 
             </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 
@@ -140,7 +140,7 @@
             <studio.carbonylgroup.textfieldboxes.ExtendedEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/description" />
+                android:text="@string/description"/>
 
         </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 
@@ -149,7 +149,31 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="30dp"
-            android:text="@string/dark_side" />
+            android:text="@string/dark_side"/>
+
+        <studio.carbonylgroup.textfieldboxes.TextFieldBoxes
+            android:id="@+id/text_field_boxes5"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            app:labelText="Coupon Code">
+
+            <studio.carbonylgroup.textfieldboxes.ExtendedEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="text"
+                android:maxLines="1"
+                android:text="@string/coupon_code"/>
+        </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
+
+        <Button
+            android:id="@+id/error_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/test_error"/>
 
     </LinearLayout>
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="price">10.00</string>
     <string name="description">Unique and rare dress from 1952. Made out of washed cotton with front pockets. Sleeveless with button closures.</string>
     <string name="dark_side">DARK SIDE</string>
+    <string name="test_error">TEST ERROR</string>
+    <string name="coupon_code">A2T3XZ9</string>
 </resources>

--- a/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
+++ b/textfieldboxes/src/main/java/studio/carbonylgroup/textfieldboxes/TextFieldBoxes.java
@@ -781,6 +781,7 @@ public class TextFieldBoxes extends FrameLayout {
             setHighlightColor(this.errorColor);
             this.helperLabel.setTextColor(this.errorColor);
             this.helperLabel.setText(errorText);
+            updateBottomViewVisibility();
             if (giveFocus) setHasFocus(true);
             makeCursorBlink();
         }
@@ -800,6 +801,7 @@ public class TextFieldBoxes extends FrameLayout {
         else setHighlightColor(this.secondaryColor);
         this.helperLabel.setTextColor(this.helperTextColor);
         this.helperLabel.setText(this.helperText);
+        updateBottomViewVisibility();
     }
 
     protected void showClearButton(boolean show) {


### PR DESCRIPTION
Right now, if helper text is empty, calling `setError()` will not show error message because after setting or removing the error, we don't update visibility of bottom bar. I also added an example in MainAcivity to test it.