### PR TITLE
Layout updated to support bigger clear icon and end icons to have 48d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+.idea/*

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,10 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7">
     <output url="file://$PROJECT_DIR$/build/classes" />
-  </component>
-  <component name="ProjectType">
-    <option name="id" value="Android" />
   </component>
 </project>

--- a/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
+++ b/sample/src/main/java/studio/carbonylgroup/textfieldboxestest/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -38,6 +39,31 @@ public class MainActivity extends AppCompatActivity {
 
         setupDarkThemeButton(dark);
         setupErrorButton();
+        setupPasswordField();
+    }
+
+    private void setupPasswordField() {
+        final Button addClearIconButton = findViewById(R.id.clear_icon_button);
+        final Button addEndIconButton = findViewById(R.id.end_icon_button);
+        final TextFieldBoxes passwordField = findViewById(R.id.text_field_boxes6);
+
+        addClearIconButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                passwordField.setHasClearButton(!passwordField.getHasClearButton());
+            }
+        });
+
+        addEndIconButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (passwordField.getEndIconImageButton().getDrawable() == null) {
+                    passwordField.setEndIcon(R.drawable.ic_visibility_black_24dp);
+                } else {
+                    passwordField.removeEndIcon();
+                }
+            }
+        });
     }
 
     private void setupDarkThemeButton(final boolean dark) {
@@ -57,7 +83,7 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
-    private void setupErrorButton(){
+    private void setupErrorButton() {
         final Button errorButton = findViewById(R.id.error_button);
         final TextFieldBoxes errorField = findViewById(R.id.text_field_boxes5);
         errorButton.setOnClickListener(new View.OnClickListener() {

--- a/sample/src/main/res/drawable/ic_visibility_black_24dp.xml
+++ b/sample/src/main/res/drawable/ic_visibility_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+</vector>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -175,6 +175,41 @@
             android:layout_marginTop="16dp"
             android:text="@string/test_error" />
 
+
+        <studio.carbonylgroup.textfieldboxes.TextFieldBoxes
+            android:id="@+id/text_field_boxes6"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:labelText="Password"
+            app:hasFocus="true"
+            app:isResponsiveIconColor="true">
+
+            <studio.carbonylgroup.textfieldboxes.ExtendedEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="textPassword"
+                android:textSize="18sp"
+                android:maxLines="1"
+                android:text="Very very very long password string. Lorem ipsum dolor sit amet" />
+
+        </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
+
+        <Button
+            android:id="@+id/clear_icon_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/clear_icon_button" />
+
+        <Button
+            android:id="@+id/end_icon_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/end_icon_button" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="dark_side">DARK SIDE</string>
     <string name="test_error">TEST ERROR</string>
     <string name="coupon_code">A2T3XZ9</string>
+    <string name="clear_icon_button">Show/Hide Clear Icon</string>
+    <string name="end_icon_button">Add/Remove End Icon</string>
 </resources>

--- a/textfieldboxes/src/main/res/layout/text_field_boxes_layout.xml
+++ b/textfieldboxes/src/main/res/layout/text_field_boxes_layout.xml
@@ -1,8 +1,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal">
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
 
     <android.support.v7.widget.AppCompatImageButton
         android:id="@+id/text_field_boxes_imageView"
@@ -13,7 +13,7 @@
         android:layout_marginTop="@dimen/icon_signifier_marginTop"
         android:background="?selectableItemBackgroundBorderless"
         android:contentDescription="@string/icon"
-        android:visibility="gone" />
+        android:visibility="gone"/>
 
     <RelativeLayout
         android:id="@+id/text_field_boxes_right_shell"
@@ -42,7 +42,7 @@
                 android:layout_alignLeft="@+id/text_field_boxes_upper_panel"
                 android:layout_alignRight="@+id/text_field_boxes_upper_panel"
                 android:layout_alignStart="@+id/text_field_boxes_upper_panel"
-                android:layout_below="@+id/text_field_boxes_upper_panel" />
+                android:layout_below="@+id/text_field_boxes_upper_panel"/>
 
             <RelativeLayout
                 android:id="@+id/text_field_boxes_upper_panel"
@@ -59,10 +59,12 @@
                 <android.support.v7.widget.AppCompatTextView
                     android:id="@+id/text_field_boxes_label"
                     android:layout_width="wrap_content"
+                    android:includeFontPadding="false"
+                    android:gravity="center"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/label_idle_margin_top"
                     android:textSize="@dimen/label_text_size"
-                    tools:text="Label" />
+                    tools:text="Label"/>
 
                 <android.support.v4.widget.Space
                     android:id="@+id/text_field_boxes_label_space"
@@ -72,51 +74,50 @@
                     android:layout_alignLeft="@+id/text_field_boxes_editTextLayout"
                     android:layout_alignParentTop="true"
                     android:layout_alignRight="@+id/text_field_boxes_editTextLayout"
-                    android:layout_alignStart="@+id/text_field_boxes_editTextLayout" />
+                    android:layout_alignStart="@+id/text_field_boxes_editTextLayout"/>
 
-                <RelativeLayout
+                <FrameLayout
                     android:id="@+id/text_field_boxes_editTextLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/text_field_boxes_label_space"
-                    android:layout_gravity="bottom"
-                    android:paddingBottom="@dimen/editTextLayout_padding_bottom"
-                    android:paddingTop="@dimen/editTextLayout_padding_top">
+                    android:layout_gravity="bottom">
 
                     <RelativeLayout
                         android:id="@+id/text_field_boxes_input_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:padding="0dp" />
+                        android:padding="0dp">
+                    </RelativeLayout>
 
-                    <android.support.v7.widget.AppCompatImageButton
-                        android:id="@+id/text_field_boxes_clear_button"
-                        android:layout_width="@dimen/clear_button_width"
-                        android:layout_height="@dimen/clear_button_height"
-                        android:layout_alignBottom="@+id/text_field_boxes_input_layout"
-                        android:layout_marginLeft="@dimen/clear_button_marginStart"
-                        android:layout_marginStart="@dimen/clear_button_marginStart"
-                        android:layout_toEndOf="@+id/text_field_boxes_input_layout"
-                        android:layout_toRightOf="@+id/text_field_boxes_input_layout"
-                        android:background="?selectableItemBackgroundBorderless"
-                        android:paddingTop="@dimen/clear_button_paddingTop"
-                        android:src="@drawable/ic_clear_circle_black_24dp"
-                        android:visibility="gone" />
+                    <LinearLayout
+                        android:background="@android:color/transparent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="bottom|end"
+                        android:orientation="horizontal">
 
-                    <android.support.v7.widget.AppCompatImageButton
-                        android:id="@+id/text_field_boxes_end_icon_button"
-                        android:layout_width="@dimen/end_icon_width"
-                        android:layout_height="@dimen/end_icon_height"
-                        android:layout_alignBottom="@+id/text_field_boxes_input_layout"
-                        android:layout_marginLeft="@dimen/end_icon_marginStart"
-                        android:layout_marginStart="@dimen/end_icon_marginStart"
-                        android:layout_toEndOf="@+id/text_field_boxes_clear_button"
-                        android:layout_toRightOf="@+id/text_field_boxes_clear_button"
-                        android:background="?selectableItemBackgroundBorderless"
-                        android:paddingTop="@dimen/end_icon_paddingTop"
-                        android:visibility="gone" />
+                        <android.support.v7.widget.AppCompatImageButton
+                            android:id="@+id/text_field_boxes_clear_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="?selectableItemBackgroundBorderless"
+                            android:minHeight="@dimen/clear_button_min_height"
+                            android:minWidth="@dimen/clear_button_min_width"
+                            android:src="@drawable/ic_clear_circle_black_24dp"
+                            android:visibility="gone"/>
 
-                </RelativeLayout>
+                        <android.support.v7.widget.AppCompatImageButton
+                            android:id="@+id/text_field_boxes_end_icon_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="?selectableItemBackgroundBorderless"
+                            android:minHeight="@dimen/end_icon_min_height"
+                            android:minWidth="@dimen/end_icon_min_width"
+                            android:visibility="gone"/>
+                    </LinearLayout>
+
+                </FrameLayout>
 
                 <android.support.v4.widget.Space
                     android:id="@+id/text_field_boxes_label_space_below"
@@ -128,7 +129,7 @@
                     android:layout_alignStart="@+id/text_field_boxes_editTextLayout"
                     android:layout_below="@+id/text_field_boxes_editTextLayout"
                     android:background="@color/A400red"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
             </RelativeLayout>
 
@@ -159,7 +160,7 @@
                 android:layout_marginRight="@dimen/helper_marginEnd"
                 android:layout_toLeftOf="@+id/text_field_boxes_counter"
                 android:layout_toStartOf="@+id/text_field_boxes_counter"
-                android:textSize="@dimen/helper_text_size" />
+                android:textSize="@dimen/helper_text_size"/>
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/text_field_boxes_counter"
@@ -167,7 +168,7 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
-                android:textSize="@dimen/counter_text_size" />
+                android:textSize="@dimen/counter_text_size"/>
 
         </RelativeLayout>
 

--- a/textfieldboxes/src/main/res/values/dimen.xml
+++ b/textfieldboxes/src/main/res/values/dimen.xml
@@ -23,18 +23,13 @@
     <dimen name="editTextLayout_padding_bottom">8dp</dimen>
     <dimen name="helper_marginEnd">8dp</dimen>
     <dimen name="bottom_line_height">2dp</dimen>
-    <dimen name="label_space_height">10dp</dimen>
+    <dimen name="label_space_height">8dp</dimen>
     <dimen name="icon_signifier_width">24dp</dimen>
     <dimen name="icon_signifier_height">24dp</dimen>
     <dimen name="icon_signifier_marginEnd">16dp</dimen>
     <dimen name="icon_signifier_marginTop">20dp</dimen>
-    <dimen name="end_icon_width">24dp</dimen>
-    <dimen name="end_icon_height">24dp</dimen>
-    <dimen name="end_icon_marginStart">2dp</dimen>
-    <dimen name="end_icon_paddingTop">2dp</dimen>
-    <dimen name="clear_button_width">24dp</dimen>
-    <dimen name="clear_button_height">24dp</dimen>
-    <dimen name="clear_button_marginStart">2dp</dimen>
-    <dimen name="clear_button_paddingTop">2dp</dimen>
-
+    <dimen name="end_icon_min_width">48dp</dimen>
+    <dimen name="end_icon_min_height">48dp</dimen>
+    <dimen name="clear_button_min_width">48dp</dimen>
+    <dimen name="clear_button_min_height">48dp</dimen>
 </resources>


### PR DESCRIPTION
I was going to work on password visibility toggle, but before we do that we need to increase touch area of icons and change the layout.

In the current version, icons are 24dp and they are set to align with EditText. That's good to align them, however, when we use a larger icon, the icon is cut from the top. I don't know if it is a bug in the Android framework. 

I replaced the RelativeLayout with a FrameLayout and placed icons on top of that. After that I calculate width of (endIcon/clearIcon or both) and put a fake drawableRight to EditText. This is how TextInputLayout works.

There are some major changes but it looks similar to what we have and touch are is better now. Let me know if you have any concerns.