### PR TITLE
Reflect 1.4.5 in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ allprojects {
 ```
 ```groovy
 dependencies {
-    compile 'com.github.HITGIF:TextFieldBoxes:1.4.4'
+    compile 'com.github.HITGIF:TextFieldBoxes:1.4.5'
 }
 ```
 
@@ -68,7 +68,7 @@ dependencies {
 <dependency>
     <groupId>com.github.HITGIF</groupId>
     <artifactId>TextFieldBoxes</artifactId>
-    <version>1.4.4</version>
+    <version>1.4.5</version>
 </dependency>
 ```
 
@@ -77,7 +77,7 @@ dependencies {
 resolvers += "jitpack" at "https://jitpack.io"
 ```
 ```scala
-libraryDependencies += "com.github.HITGIF" % "TextFieldBoxes" % "1.4.4"
+libraryDependencies += "com.github.HITGIF" % "TextFieldBoxes" % "1.4.5"
 ```
 
 
@@ -86,7 +86,7 @@ libraryDependencies += "com.github.HITGIF" % "TextFieldBoxes" % "1.4.4"
 :repositories [["jitpack" "https://jitpack.io"]]
 ```
 ```scala
-:dependencies [[com.github.hitgif/textfieldboxes "1.4.4"]]
+:dependencies [[com.github.hitgif/textfieldboxes "1.4.5"]]
 ```
 
 ​


### PR DESCRIPTION
This will avoid issues for new users who can miss the update text on the readme. 